### PR TITLE
Use ES6 generator as listener handler, add namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,31 @@ var app = koa();
 
 app.use( ... );
 
+var io = socket.start( app );
+
+io.on( 'join', function *( data ) {
+  yield console.log( 'join event fired', data );
+});
+
+app.server.listen( process.env.PORT || 3000 );
+```
+
+## Namespaces
+
+```
+var koa = require( 'koa' );
+var socket = require( 'koa-socket' );
+
+var app = koa();
+
+app.use( ... );
+
 socket.start( app );
 
-socket.on( 'join', function( data ) {
-  console.log( 'join event fired', data );
+var nsp = socket.of( '/my-namespace' );
+
+nsp.on( 'join', function *( data ) {
+  yield console.log( 'join event fired', data );
 });
 
 app.server.listen( process.env.PORT || 3000 );
@@ -59,7 +80,7 @@ socket.emit( 'event', {
 });
 
 // Listening on the server
-socket.on( 'event', function( packet ) {
+socket.on( 'event', function *( packet ) {
   // Id now exists on the packet thanks to middleware
   // Although in this trivial example it can be referenced on the context
   console.log( packet.id );

--- a/README.md
+++ b/README.md
@@ -41,8 +41,14 @@ socket.start( app );
 
 var nsp = socket.of( '/my-namespace' );
 
+var nsp2 = socket.of( '/my-another-namespace' );
+
 nsp.on( 'join', function *( data ) {
-  yield console.log( 'join event fired', data );
+  yield console.log( 'join event fired in my namespace', data );
+});
+
+nsp2.on( 'join', function *( data ) {
+  yield console.log( 'join event fired in anoth namespace', data );
 });
 
 app.server.listen( process.env.PORT || 3000 );

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var io = null;
 /**
  * Store initialed namespaces
  */
-var nps = [];
+var namespaces = [];
 
 
 /**
@@ -47,7 +47,12 @@ koaSocket.start = function( koa ) {
 
     koa.server = http.createServer( koa.callback() );
     io = koa.io = socketIO( koa.server );
-    return new Namespace(io, _middleware);
+    var ns = new Namespace(io, _middleware);
+    namespaces.push({
+        path: '/',
+        io: ns
+    });
+    return ns;
 };
 
 
@@ -73,6 +78,30 @@ koaSocket.of = function( path ) {
         return;
     }
 
-    return new Namespace(io, _middleware, path);
-}
+    var ns = null;
+
+    namespaces.forEach(function( nsp ) {
+        if ( path == nsp.path ) {
+            ns = nsp.io;
+        }
+    });
+
+    if (!!ns) {
+        return ns;
+    }
+
+    var ns = new Namespace(io, _middleware, path);
+    namespaces.push({
+        path: path,
+        io: ns
+    });
+    return ns;
+};
+
+/**
+ * Get all namespaces data
+ */
+koaSocket.getNamespaces = function() {
+    return namespaces;
+};
 

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ koaSocket.use = function( fn ) {
  * @param path {String}
  */
 koaSocket.of = function( path ) {
-    if ( !socket ) {
+    if ( !io ) {
         console.error( 'Connection not exists!' );
         return;
     }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 
 var http = require( 'http' ),
     socketIO = require( 'socket.io' ),
-    Socket = require( './lib/namespace' );
+    Namespace = require( './lib/namespace' );
 
 
 /**

--- a/index.js
+++ b/index.js
@@ -7,20 +7,7 @@
 
 var http = require( 'http' ),
     socketIO = require( 'socket.io' ),
-
-    Socket = require( './lib/socket' );
-
-
-/**
- * Listeners ready to attach to a socket instance
- */
-var _listeners = [];
-
-
-/**
- * List of id's of active connections
- */
-var _connections = [];
+    Socket = require( './lib/namespace' );
 
 
 /**
@@ -30,22 +17,21 @@ var _middleware = [];
 
 
 /**
+ * Socket.io connection handler.
+ */
+var io = null;
+
+
+/**
+ * Store initialed namespaces
+ */
+var nps = [];
+
+
+/**
  * Expose object to manage attaching listeners to connections
  */
 var koaSocket = module.exports = {};
-
-
-/**
- * Connection callback.
- * Expects to pass the socket to the callback.
- */
-koaSocket.onConnect = null;
-
-/**
- * Discount callback.
- * Expects to pass the socket to the callback.
- */
-koaSocket.onDisconnect = null;
 
 
 /**
@@ -60,9 +46,8 @@ koaSocket.start = function( koa ) {
     }
 
     koa.server = http.createServer( koa.callback() );
-    koa.io = socketIO( koa.server );
-
-    koa.io.on( 'connection', onConnect );
+    io = koa.io = socketIO( koa.server );
+    return new Namespace(io, _middleware);
 };
 
 
@@ -78,114 +63,16 @@ koaSocket.use = function( fn ) {
 
 
 /**
- * Getter for the list of connected sockets
+ * Initializes and retrieves the given Namespace by its pathname
  *
- * @returns {array}
+ * @param path {String}
  */
-koaSocket.getConnections = function() {
-    return _connections;
-};
-
-
-/**
- * Stores a listener, ready to attach.
- *
- * @param event {String} name of event
- * @param handler {Function} the callback to fire on event
- */
-koaSocket.on = function( event, handler ) {
-    if ( event === 'connection' ) {
-        koaSocket.onConnect = handler;
+koaSocket.of = function( path ) {
+    if ( !socket ) {
+        console.error( 'Connection not exists!' );
         return;
     }
 
-    if ( event === 'disconnect' ) {
-        koaSocket.onDisconnect = handler;
-        return;
-    }
-
-    _listeners.push({
-        event: event,
-        handler: handler
-    });
-};
-
-
-/**
- * Binds listeners to the socket connection
- *
- * @param socket - socket.io socket connection
- */
-koaSocket.attach = function( socket ) {
-    var sock = new Socket( socket, _listeners, _middleware );
-    addConnection( socket );
-    return sock;
-};
-
-
-
-/**
- * @get numConnections
- */
-Object.defineProperty( koaSocket, 'numConnections', {
-    get: function() {
-        return _connections.length;
-    }
-});
-
-
-/**
- * Adds a new connection to the list
- *
- * @param socket {Socket instance}
- * @private
- */
-function addConnection( socket ) {
-    _connections.push({
-        id: socket.id,
-        socket: socket
-    });
+    return new Namespace(io, _middleware, path);
 }
 
-
-/**
- * Removes a connection from the list
- */
-function removeConnection( id ) {
-    var i = _connections.length - 1;
-    while( i > 0 ) {
-        if ( _connections[ i ].id === id ) {
-            break;
-        }
-        i--;
-    }
-
-    _connections.splice( i, 1 );
-}
-
-
-/**
- * Fired when a socket connects to the server.
- * Attaches the socket to koaSocket and sets up a disconnect event.
- *
- * @param socket {socket connection}
- */
-function onConnect( socket ) {
-    console.log( 'Socket connected', socket.id );
-    socket.on( 'disconnect', onDisconnect );
-    if ( koaSocket.onConnect ) {
-        koaSocket.onConnect( socket );
-    }
-    koaSocket.attach( socket );
-}
-
-/**
- * Fired when a socket disconnects from the server,
- */
-function onDisconnect() {
-    console.log( 'Socket disconnected', this.id );
-    if ( koaSocket.onDisconnect ) {
-        koaSocket.onDisconnect( this );
-    }
-    removeConnection( this.id );
-}

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -41,8 +41,8 @@ var Namespace = module.exports = function( io, middleware, path ) {
 
     this.io = io;
 
-    if (!!namespace) {
-        this.io = io.of(namespace);
+    if (!!path) {
+        this.io = io.of(path);
     }
 
     this.io.on( 'connection', function( socket ) {

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -145,7 +145,6 @@ Namespace.prototype.addConnection = function( socket ) {
 /**
  * Removes a connection from the list
  */
- */
 Namespace.prototype.removeConnection = function( id ) {
     var i = this._connections.length - 1;
     while( i > 0 ) {

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -1,0 +1,159 @@
+
+ var Socket = require( './lib/socket' );
+
+
+/**
+ * Namespace constructor.
+ * Called when a connection init.
+ *
+ * @param io {socket.io connection handler}
+ * @param middleware {Array} list of middleware to pass event data through
+ * @param path {string} namespace path
+ */
+var Namespace = module.exports = function( io, middleware, path ) {
+
+    /**
+     * Listeners ready to attach to a socket instance
+     */
+    this._listeners = [];
+
+    /**
+     * List of id's of active connections
+     */
+    this._connections = [];
+
+    /**
+     * Middleware list
+     */
+    this._middleware = middleware;
+
+    /**
+     * Connection callback.
+     * Expects to pass the socket to the callback.
+     */
+    this.onConnect = null;
+
+    /**
+     * Discount callback.
+     * Expects to pass the socket to the callback.
+     */
+    this.onDisconnect = null;
+
+    this.io = io;
+
+    if (!!namespace) {
+        this.io = io.of(namespace);
+    }
+
+    this.init();
+};
+
+
+/**
+ * Initialises the connection
+ */
+Namespace.prototype.init = function() {
+
+    var self = this;
+
+    this.nsp.on( 'connection', function( socket ) {
+        console.log( 'Socket connected', socket.id );
+
+        socket.on( 'disconnect', function() {
+            console.log( 'Socket disconnected', this.id );
+            if ( self.onDisconnect ) {
+                self.onDisconnect( this );
+            }
+            self.removeConnection( this.id );
+        });
+        
+        if ( self.onConnect ) {
+            self.onConnect( socket );
+        }
+        self.attach( socket );
+    });
+
+    /**
+    * @get numConnections
+    */
+    Object.defineProperty( this, 'numConnections', {
+        get: function() {
+            return this._connections.length;
+        }
+    });
+};
+
+/**
+ * Getter for the list of connected sockets
+ *
+ * @returns {array}
+ */
+Namespace.prototype.getConnections = function() {
+    return this._connections;
+};
+
+
+/**
+ * Stores a listener, ready to attach.
+ *
+ * @param event {String} name of event
+ * @param handler {Function} the callback to fire on event
+ */
+Namespace.prototype.on = function( event, handler ) {
+    if ( event === 'connection' ) {
+        this.onConnect = handler;
+        return;
+    }
+
+    if ( event === 'disconnect' ) {
+        this.onDisconnect = handler;
+        return;
+    }
+
+    this._listeners.push({
+        event: event,
+        handler: handler
+    });
+};
+
+
+/**
+ * Binds listeners to the socket connection
+ *
+ * @param socket - socket.io socket connection
+ */
+Namespace.prototype.attach = function( socket ) {
+    var sock = new Socket( socket, this._listeners, this._middleware );
+    this.addConnection( socket );
+    return sock;
+};
+
+/**
+ * Adds a new connection to the list
+ *
+ * @param socket {Socket instance}
+ * @private
+ */
+Namespace.prototype.addConnection = function( socket ) {
+    this._connections.push({
+        id: socket.id,
+        socket: socket
+    });
+};
+
+
+/**
+ * Removes a connection from the list
+ */
+ */
+Namespace.prototype.removeConnection = function( id ) {
+    var i = this._connections.length - 1;
+    while( i > 0 ) {
+        if ( this._connections[ i ].id === id ) {
+            break;
+        }
+        i--;
+    }
+
+    this._connections.splice( i, 1 );
+};

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -1,5 +1,5 @@
 
- var Socket = require( './lib/socket' );
+ var Socket = require( './socket' );
 
 
 /**

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -39,6 +39,9 @@ var Namespace = module.exports = function( io, middleware, path ) {
      */
     var onDisconnect = null;
 
+    // namespace
+    var namespace = path? path: '/';
+
     this.io = io;
 
     if (!!path) {
@@ -46,10 +49,10 @@ var Namespace = module.exports = function( io, middleware, path ) {
     }
 
     this.io.on( 'connection', function( socket ) {
-        console.log( 'Socket connected', socket.id );
+        console.log( '[' + namespace + ']Socket connected', socket.id );
 
         socket.on( 'disconnect', function() {
-            console.log( 'Socket disconnected', this.id );
+            console.log( '[' + namespace + ']Socket disconnected', this.id );
             if ( onDisconnect ) {
                 onDisconnect( this );
             }
@@ -109,37 +112,37 @@ var Namespace = module.exports = function( io, middleware, path ) {
         addConnection( socket );
         return sock;
     };
-};
 
-/**
- * Getter for the list of connected sockets
- *
- * @returns {array}
- */
-Namespace.prototype.getConnections = function() {
-    return _connections;
-};
+    /**
+     * Getter for the list of connected sockets
+     *
+     * @returns {array}
+     */
+    this.getConnections = function() {
+        return _connections;
+    };
 
 
-/**
- * Stores a listener, ready to attach.
- *
- * @param event {String} name of event
- * @param handler {Function} the callback to fire on event
- */
-Namespace.prototype.on = function( event, handler ) {
-    if ( event === 'connection' ) {
-        this.onConnect = handler;
-        return;
-    }
+    /**
+     * Stores a listener, ready to attach.
+     *
+     * @param event {String} name of event
+     * @param handler {Function} the callback to fire on event
+     */
+    this.on = function( event, handler ) {
+        if ( event === 'connection' ) {
+            onConnect = handler;
+            return;
+        }
 
-    if ( event === 'disconnect' ) {
-        this.onDisconnect = handler;
-        return;
-    }
+        if ( event === 'disconnect' ) {
+            onDisconnect = handler;
+            return;
+        }
 
-    _listeners.push({
-        event: event,
-        handler: handler
-    });
+        _listeners.push({
+            event: event,
+            handler: handler
+        });
+    };
 };

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -15,29 +15,29 @@ var Namespace = module.exports = function( io, middleware, path ) {
     /**
      * Listeners ready to attach to a socket instance
      */
-    this._listeners = [];
+    var _listeners = [];
 
     /**
      * List of id's of active connections
      */
-    this._connections = [];
+    var _connections = [];
 
     /**
      * Middleware list
      */
-    this._middleware = middleware;
+    var _middleware = middleware;
 
     /**
      * Connection callback.
      * Expects to pass the socket to the callback.
      */
-    this.onConnect = null;
+    var onConnect = null;
 
     /**
      * Discount callback.
      * Expects to pass the socket to the callback.
      */
-    this.onDisconnect = null;
+    var onDisconnect = null;
 
     this.io = io;
 
@@ -45,32 +45,21 @@ var Namespace = module.exports = function( io, middleware, path ) {
         this.io = io.of(namespace);
     }
 
-    this.init();
-};
-
-
-/**
- * Initialises the connection
- */
-Namespace.prototype.init = function() {
-
-    var self = this;
-
-    this.nsp.on( 'connection', function( socket ) {
+    this.io.on( 'connection', function( socket ) {
         console.log( 'Socket connected', socket.id );
 
         socket.on( 'disconnect', function() {
             console.log( 'Socket disconnected', this.id );
-            if ( self.onDisconnect ) {
-                self.onDisconnect( this );
+            if ( onDisconnect ) {
+                onDisconnect( this );
             }
-            self.removeConnection( this.id );
+            removeConnection( this.id );
         });
         
-        if ( self.onConnect ) {
-            self.onConnect( socket );
+        if ( onConnect ) {
+            onConnect( socket );
         }
-        self.attach( socket );
+        attach( socket );
     });
 
     /**
@@ -78,9 +67,48 @@ Namespace.prototype.init = function() {
     */
     Object.defineProperty( this, 'numConnections', {
         get: function() {
-            return this._connections.length;
+            return _connections.length;
         }
     });
+
+    /**
+     * Adds a new connection to the list
+     *
+     * @param socket {Socket instance}
+     * @private
+     */
+    function addConnection( socket ) {
+        _connections.push({
+            id: socket.id,
+            socket: socket
+        });
+    };
+
+    /**
+     * Removes a connection from the list
+     */
+    function removeConnection( id ) {
+        var i = _connections.length - 1;
+        while( i > 0 ) {
+            if ( _connections[ i ].id === id ) {
+                break;
+            }
+            i--;
+        }
+
+        _connections.splice( i, 1 );
+    };
+
+    /**
+     * Binds listeners to the socket connection
+     *
+     * @param socket - socket.io socket connection
+     */
+    function attach( socket ) {
+        var sock = new Socket( socket, _listeners, _middleware );
+        addConnection( socket );
+        return sock;
+    };
 };
 
 /**
@@ -89,7 +117,7 @@ Namespace.prototype.init = function() {
  * @returns {array}
  */
 Namespace.prototype.getConnections = function() {
-    return this._connections;
+    return _connections;
 };
 
 
@@ -110,49 +138,8 @@ Namespace.prototype.on = function( event, handler ) {
         return;
     }
 
-    this._listeners.push({
+    _listeners.push({
         event: event,
         handler: handler
     });
-};
-
-
-/**
- * Binds listeners to the socket connection
- *
- * @param socket - socket.io socket connection
- */
-Namespace.prototype.attach = function( socket ) {
-    var sock = new Socket( socket, this._listeners, this._middleware );
-    this.addConnection( socket );
-    return sock;
-};
-
-/**
- * Adds a new connection to the list
- *
- * @param socket {Socket instance}
- * @private
- */
-Namespace.prototype.addConnection = function( socket ) {
-    this._connections.push({
-        id: socket.id,
-        socket: socket
-    });
-};
-
-
-/**
- * Removes a connection from the list
- */
-Namespace.prototype.removeConnection = function( id ) {
-    var i = this._connections.length - 1;
-    while( i > 0 ) {
-        if ( this._connections[ i ].id === id ) {
-            break;
-        }
-        i--;
-    }
-
-    this._connections.splice( i, 1 );
 };

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -19,10 +19,12 @@ var compose = require( 'koa-compose' ),
  * @returns {Array} the new list of functions forming the event chain
  */
 var composer = function( listener, middleware ) {
-    return [ function *( next ) {
+    return middleware.concat([ function *( next ) {
         yield next;
-        listener.handler.call( this.socket, this.data );
-    }].concat( middleware );
+        // use ES6 generator as event handler
+        var fn = co(listener.handler);
+        fn.call( this.socket, this.data );
+    }]);
 };
 
 


### PR DESCRIPTION
* Use ES6 generator as event handler, code like this looks better.
```javascript
	socket.on('todo:get', function *(data) {
		var res = yield todos.get;
		this.emit('todo:get', res);
	});
```
* Fix the calling sequence to middleware -> event listener, the previous one event listener called first, some middleware like logger could not determine the code execution time.