### PR TITLE
use existing app.server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ app.server.listen( process.env.PORT || 3000 )
 
 ## Attaching to existing projects
 
-The `attach` function is used to attach the `IO` instance to the application, this adds `server` and `io` properties to the koa application and should happen before the app starts listening on a port.
+The `attach` function is used to attach the `IO` instance to the application, this adds `server`\* and `io` properties to the koa application and should happen before the app starts listening on a port. \*If `app.server` already exists (as an http server), it uses that instead.
 
 The only change you need to make to your existing code is to start the server listening by calling `app.server.listen` rather than `app.listen` (you’ll get a console warning if you get it wrong ;) ).
 

--- a/spec/attach.test.js
+++ b/spec/attach.test.js
@@ -35,7 +35,18 @@ tape( 'should not alter a koa app that already has ._io unless called with a nam
   }, null, 'calling .attach throws an error when ._io already exists without a namespace' )
 })
 
-tape( 'should not alter a koa app that already has .server', t => {
+tape( 'should work with koa app that already has .server', t => {
+  t.plan( 1 )
+
+  const app = new Koa()
+  const socket = new IO()
+  app.server = http.createServer()
+  socket.attach( app )
+
+  t.ok( app.io, 'socket is attached to koa app' )
+})
+
+tape( 'shouldn\'t work if app.server exists but it\'s not an http server', t => {
   t.plan( 1 )
 
   const app = new Koa()
@@ -44,7 +55,7 @@ tape( 'should not alter a koa app that already has .server', t => {
 
   t.throws( () => {
     socket.attach( app )
-  }, null, 'calling .attach throws an error when .server already exists' )
+  }, null, 'calling .attach throws an error when .server already exists but it\'s not an http server' )
 })
 
 tape( 'Attaching a namespace to a koa app with socket.io existing is all cool', t => {


### PR DESCRIPTION
Checks to see if `app.server` exists, if so, uses that, if not, creates one.

Wraps `app.listen` with warning *only* if `app.server` was created here.

Doesn't throw error if `app.server` exists (this is causing to fail 1 test in `attach.test.js` 'should not alter a koa app that already has .server')
