### PR TITLE
allows using `app.listen` instead of `app.server.listen`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ io.on( 'join', ( ctx, data ) => {
   console.log( 'join event fired', data )
 })
 
-app.server.listen( process.env.PORT || 3000 )
+app.listen( process.env.PORT || 3000 )
 ```
 
 ## Features
@@ -48,9 +48,9 @@ app.server.listen( process.env.PORT || 3000 )
 
 ## Attaching to existing projects
 
-The `attach` function is used to attach the `IO` instance to the application, this adds `server`\* and `io` properties to the koa application and should happen before the app starts listening on a port. \*If `app.server` already exists (as an http server), it uses that instead.
+The `attach` function is used to attach the `IO` instance to the application, this adds `server`\* and `io` properties to the koa application and should happen before the app starts listening on a port.
 
-The only change you need to make to your existing code is to start the server listening by calling `app.server.listen` rather than `app.listen` (you’ll get a console warning if you get it wrong ;) ).
+It also re-maps `app.listen` to `app.server.listen`, so you could simply do `app.listen()`. However if you already had an `app.server` attached, it uses it instead and expects you to do `app.server.listen()` yourself.
 
 ```js
 const Koa = require( 'koa' )
@@ -70,10 +70,12 @@ app._io.on( 'connection', sock => {
   // ...
 })
 
-// Make sure the `app.server` instance starts listening on a port
+// app.listen is mapped to app.server.listen, so you can just do:
+app.listen( process.env.PORT || 3000 )
+
+// *If* you had manually attached an `app.server` yourself, you should do:
 app.server.listen( process.env.PORT || 3000 )
 ```
-
 
 ## Middleware and event handlers
 
@@ -106,7 +108,7 @@ io.on( 'message', ( ctx, data ) => {
 })
 
 io.attach( app )
-app.server.listen( 3000 );
+app.listen( 3000 );
 ```
 
 ### Example with *async* functions (transpilation required)
@@ -228,7 +230,7 @@ Attaches to a koa application
 
 ```js
 io.attach( app )
-app.server.listen( process.env.PORT )
+app.listen( process.env.PORT )
 ```
 
 ### .use( `Function callback` )

--- a/index.js
+++ b/index.js
@@ -105,13 +105,9 @@ module.exports = class IO {
     if ( !app.server ) {
       // Create a server if it doesn't already exists
       app.server = http.createServer( app.callback() )
-
-      // Add warning to conventional .listen
-      // @TODO should this just be removed?
-      app.__listen = app.listen
-      app.listen = function listen() {
-        console.warn( 'IO is attached, did you mean app.server.listen()' )
-        return app.__listen.apply( app, arguments )
+      // Patch `app.listen()` to call `app.server.listen()`
+      app.listen = function listen(){
+        app.server.listen.call(app.server, arguments);
       }
     }
 

--- a/spec/attach.test.js
+++ b/spec/attach.test.js
@@ -171,22 +171,20 @@ tape( 'The default namespace can not be hidden, app.io must be attached to app',
   }, null, 'Attaching a hidden default instance will throw' )
 })
 
-tape( 'Calling app.listen logs a console warning message', t => {
+tape( 'Calling app.listen calls app.server.listen', t => {
   t.plan( 2 )
-
-  const prev = console.warn
-  console.warn = function() {
-    t.pass( 'Calling app.listen generated a console warning' )
-  }
 
   const app = new Koa()
   const io = new IO()
 
   io.attach( app )
 
+  app.server.listen = function() {
+    t.pass( 'Calling app.listen called app.server.listen' )
+  }
+
   t.doesNotThrow( () => {
     var srv = app.listen( () => {
-      console.warn = prev
       srv.close()
     })
   }, 'Calling app.listen does not throw' )


### PR DESCRIPTION
allows using `app.listen` instead of `app.server.listen`

`app.listen` is re-mapped to `app.server.listen` (only if `app.server` was created here)

For advanced user (if `app.server` already existed), it is assumed that they will manually call `app.server.listen()`.